### PR TITLE
Save the original sent time for received MMS messages.

### DIFF
--- a/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
+++ b/library/src/main/java/com/android/mms/service_alt/DownloadRequest.java
@@ -187,6 +187,7 @@ public class DownloadRequest extends MmsRequest {
             // Update some of the properties of the message
             final ContentValues values = new ContentValues();
             values.put(Telephony.Mms.DATE, System.currentTimeMillis() / 1000L);
+            values.put(Telephony.Mms.DATE_SENT, retrieveConf.getDate());
             values.put(Telephony.Mms.READ, 0);
             values.put(Telephony.Mms.SEEN, 0);
             if (!TextUtils.isEmpty(creator)) {

--- a/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
+++ b/library/src/main/java/com/android/mms/service_alt/MmsRequestManager.java
@@ -89,8 +89,10 @@ public class MmsRequestManager implements MmsRequest.RequestManager {
                     group, null);
 
             // Use local time instead of PDU time
-            ContentValues values = new ContentValues(2);
+            ContentValues values = new ContentValues(3);
             values.put(Telephony.Mms.DATE, System.currentTimeMillis() / 1000L);
+            // Store PDU time as sent time for received message
+            values.put(Telephony.Mms.DATE_SENT, retrieveConf.getDate());
             values.put(Telephony.Mms.MESSAGE_SIZE, response.length);
             SqliteWrapper.update(context, context.getContentResolver(),
                     msgUri, values, null, null);

--- a/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/NotificationTransaction.java
@@ -40,6 +40,7 @@ import com.google.android.mms.pdu_alt.PduComposer;
 import com.google.android.mms.pdu_alt.PduHeaders;
 import com.google.android.mms.pdu_alt.PduParser;
 import com.google.android.mms.pdu_alt.PduPersister;
+import com.google.android.mms.pdu_alt.RetrieveConf;
 import com.klinker.android.logger.Log;
 import com.klinker.android.send_message.BroadcastUtils;
 
@@ -197,8 +198,11 @@ public class NotificationTransaction extends Transaction implements Runnable {
                             com.klinker.android.send_message.Transaction.settings.getGroup(), null);
 
                     // Use local time instead of PDU time
-                    ContentValues values = new ContentValues(1);
+                    ContentValues values = new ContentValues(2);
                     values.put(Mms.DATE, System.currentTimeMillis() / 1000L);
+                    // Store PDU time as sent time for received message
+                    RetrieveConf retrieveConf = (RetrieveConf) pdu;
+                    values.put(Mms.DATE_SENT, retrieveConf.getDate());
                     SqliteWrapper.update(mContext, mContext.getContentResolver(),
                             uri, values, null, null);
 

--- a/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
+++ b/library/src/main/java/com/android/mms/transaction/RetrieveTransaction.java
@@ -168,8 +168,10 @@ public class RetrieveTransaction extends Transaction implements Runnable {
                             group, null);
 
                     // Use local time instead of PDU time
-                    ContentValues values = new ContentValues(2);
+                    ContentValues values = new ContentValues(3);
                     values.put(Mms.DATE, System.currentTimeMillis() / 1000L);
+                    // Store PDU time as sent time for received message
+                    values.put(Mms.DATE_SENT, retrieveConf.getDate());
                     values.put(Mms.MESSAGE_SIZE, resp.length);
                     SqliteWrapper.update(mContext, mContext.getContentResolver(),
                             msgUri, values, null, null);


### PR DESCRIPTION
https://cosmosia.atlassian.net/browse/COS-906

MMSで受信したメッセージの時刻について、現在は受信時刻を表示する仕組みとなっているが、送信時刻を表示できるようにしたい。
ただし、これまで受信時刻を格納していた `Telephony.MMS.DATE` カラムへ送信時刻 ( `PduHeaders.DATE` ) を格納するよう変更してしまうと、他のメッセージングアプリ等で不都合が生じるおそれがある。
そのため、受信メッセージにおいては現在使われていない `Telephony.MMS.DATE_SENT` カラムへ、新たに送信時刻を格納する。

---

現在このような実装になっている理由として、MMSサーバーのタイムゾーンの設定が正しくない場合などに、正確な時刻を取得できないためとの記載がある。
https://github.com/aosp-mirror/platform_packages_apps_mms/commit/69481afff1b27e1d8b31e1450430aeb8bc6a2d07

とはいえ、日本のMMSサービス（UQモバイルメール、S!メール等）においては上記の問題は無さそうなため、今回の対応を行う。