### PR TITLE
Make APN list loadable from outside library.

### DIFF
--- a/library/src/main/java/com/klinker/android/send_message/ApnUtils.java
+++ b/library/src/main/java/com/klinker/android/send_message/ApnUtils.java
@@ -183,7 +183,7 @@ public class ApnUtils {
                 .commit();
     }
 
-    private static ArrayList<APN> loadApns(Context context) {
+    public static ArrayList<APN> loadApns(Context context) {
         XmlResourceParser parser = context.getResources().getXml(R.xml.apns);
         ArrayList<APN> apns = new ArrayList<APN>();
         String mmsc = "", proxy = "", port = "", carrier = "";
@@ -371,7 +371,7 @@ public class ApnUtils {
         }
     }
 
-    private static class APN {
+    public static class APN {
         public String name;
         public String mmsc;
         public String proxy;


### PR DESCRIPTION
android-smsmmsライブラリ側で定義されたAPNの辞書 (apns.xml) を読み込んでCosmoSiaで利用したい。
ライブラリ側にこの辞書を読み込むコードはあるが、そのままでは今回必要のない処理も多くあるため、辞書を読み込むメソッドを直接CosmoSiaから利用できるようにした。