### PR TITLE
Specify mutability of PendingIntent

### DIFF
--- a/library/src/main/java/com/android/internal/net/VpnConfig.java
+++ b/library/src/main/java/com/android/internal/net/VpnConfig.java
@@ -53,7 +53,7 @@ public class VpnConfig implements Parcelable {
         intent.putExtra("config", config);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_NO_HISTORY |
                 Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
-        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     public String user;

--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -1,6 +1,7 @@
 
 package com.android.mms.transaction;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
@@ -77,8 +78,13 @@ public class DownloadManager {
         download.putExtra(MmsReceivedReceiver.EXTRA_TRIGGER_PUSH, byPush);
         download.putExtra(MmsReceivedReceiver.EXTRA_URI, uri);
         download.putExtra(MmsReceivedReceiver.SUBSCRIPTION_ID, subscriptionId);
+        // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+        // Actual value from:
+        // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+        final int flagMutable = 1<<25;
+        @SuppressLint("WrongConstant")
         final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                context, 0, download, PendingIntent.FLAG_CANCEL_CURRENT);
+                context, 0, download, PendingIntent.FLAG_CANCEL_CURRENT | flagMutable);
 
         final SmsManager smsManager = SmsManagerFactory.createSmsManager(subscriptionId);
 

--- a/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
+++ b/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
@@ -16,6 +16,7 @@
 
 package com.android.mms.transaction;
 
+import android.annotation.SuppressLint;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.ContentResolver;
@@ -318,8 +319,14 @@ public class RetryScheduler implements Observer {
 
                     Intent service = new Intent(TransactionService.ACTION_ONALARM,
                                         null, context, TransactionService.class);
+
+                    // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+                    // Actual value from:
+                    // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+                    final int flagMutable = 1<<25;
+                    @SuppressLint("WrongConstant")
                     PendingIntent operation = PendingIntent.getService(
-                            context, 0, service, PendingIntent.FLAG_ONE_SHOT);
+                            context, 0, service, PendingIntent.FLAG_ONE_SHOT | flagMutable);
                     AlarmManager am = (AlarmManager) context.getSystemService(
                             Context.ALARM_SERVICE);
                     am.set(AlarmManager.RTC, retryAt, operation);

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -16,6 +16,7 @@
 
 package com.klinker.android.send_message;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.*;
@@ -264,8 +265,13 @@ public class Transaction {
 
                 sentIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 sentIntent.putExtra(SENT_SMS_BUNDLE, sentMessageParcelable);
+                // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+                // Actual value from:
+                // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+                final int flagMutable = 1<<25;
+                @SuppressLint("WrongConstant")
                 PendingIntent sentPI = PendingIntent.getBroadcast(
-                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagMutable);
 
                 Intent deliveredIntent;
                 if (explicitDeliveredSmsReceiver == null) {
@@ -277,8 +283,9 @@ public class Transaction {
 
                 deliveredIntent.putExtra("message_uri", messageUri == null ? "" : messageUri.toString());
                 deliveredIntent.putExtra(DELIVERED_SMS_BUNDLE, deliveredParcelable);
+                @SuppressLint("WrongConstant")
                 PendingIntent deliveredPI = PendingIntent.getBroadcast(
-                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagMutable);
 
                 ArrayList<PendingIntent> sPI = new ArrayList<PendingIntent>();
                 ArrayList<PendingIntent> dPI = new ArrayList<PendingIntent>();
@@ -679,8 +686,13 @@ public class Transaction {
 
             intent.putExtra(MmsSentReceiver.EXTRA_CONTENT_URI, messageUri.toString());
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
+            // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+            // Actual value from:
+            // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+            final int flagMutable = 1<<25;
+            @SuppressLint("WrongConstant")
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | flagMutable);
 
             Uri writerUri = (new Uri.Builder())
                     .authority(context.getPackageName() + ".MmsFileProvider")


### PR DESCRIPTION
Without specify the mutability of PendingIntent, app will crash when targets Android 12 or higher.
https://developer.android.com/guide/components/intents-filters?hl=en#DeclareMutabilityPendingIntent