### PR TITLE
FLAG_IMMUTABLE for PendingIntent with Implicit Intents in U+ 34+

### DIFF
--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -82,13 +82,13 @@ public class DownloadManager {
         download.putExtra(MmsReceivedReceiver.EXTRA_TRIGGER_PUSH, byPush);
         download.putExtra(MmsReceivedReceiver.EXTRA_URI, uri);
         download.putExtra(MmsReceivedReceiver.SUBSCRIPTION_ID, subscriptionId);
-        // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+        // Workaround for using PendingIntent.FLAG_IMMUTABLE until compileSdkVersion is updated to 31.
         // Actual value from:
         // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
-        final int flagMutable = 1<<25;
+        final int flagImmutable = 1 << 26;
         @SuppressLint("WrongConstant")
         final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                context, 0, download, PendingIntent.FLAG_CANCEL_CURRENT | flagMutable);
+                context, 0, download, PendingIntent.FLAG_CANCEL_CURRENT | flagImmutable);
 
         final SmsManager smsManager = SmsManagerFactory.createSmsManager(subscriptionId);
 

--- a/library/src/main/java/com/android/mms/transaction/DownloadManager.java
+++ b/library/src/main/java/com/android/mms/transaction/DownloadManager.java
@@ -84,7 +84,7 @@ public class DownloadManager {
         download.putExtra(MmsReceivedReceiver.SUBSCRIPTION_ID, subscriptionId);
         // Workaround for using PendingIntent.FLAG_IMMUTABLE until compileSdkVersion is updated to 31.
         // Actual value from:
-        // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+        // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#247
         final int flagImmutable = 1 << 26;
         @SuppressLint("WrongConstant")
         final PendingIntent pendingIntent = PendingIntent.getBroadcast(

--- a/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
+++ b/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
@@ -346,13 +346,13 @@ public class RetryScheduler implements Observer {
                     Intent service = new Intent(TransactionService.ACTION_ONALARM,
                                         null, context, TransactionService.class);
 
-                    // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
+                    // Workaround for using PendingIntent.FLAG_IMMUTABLE until compileSdkVersion is updated to 31.
                     // Actual value from:
                     // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
-                    final int flagMutable = 1<<25;
+                    final int flagImmutable = 1 << 26;
                     @SuppressLint("WrongConstant")
                     PendingIntent operation = PendingIntent.getService(
-                            context, 0, service, PendingIntent.FLAG_ONE_SHOT | flagMutable);
+                            context, 0, service, PendingIntent.FLAG_ONE_SHOT | flagImmutable);
                     AlarmManager am = (AlarmManager) context.getSystemService(
                             Context.ALARM_SERVICE);
                     am.set(AlarmManager.RTC, retryAt, operation);

--- a/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
+++ b/library/src/main/java/com/android/mms/transaction/RetryScheduler.java
@@ -348,7 +348,7 @@ public class RetryScheduler implements Observer {
 
                     // Workaround for using PendingIntent.FLAG_IMMUTABLE until compileSdkVersion is updated to 31.
                     // Actual value from:
-                    // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+                    // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#247
                     final int flagImmutable = 1 << 26;
                     @SuppressLint("WrongConstant")
                     PendingIntent operation = PendingIntent.getService(

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -276,10 +276,10 @@ public class Transaction {
                 // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
                 // Actual value from:
                 // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
-                final int flagMutable = 1<<25;
+                final int flagImmutable = 1 << 26;
                 @SuppressLint("WrongConstant")
                 PendingIntent sentPI = PendingIntent.getBroadcast(
-                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagMutable);
+                        context, messageId, sentIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagImmutable);
 
                 Intent deliveredIntent;
                 if (explicitDeliveredSmsReceiver == null) {
@@ -293,7 +293,7 @@ public class Transaction {
                 deliveredIntent.putExtra(DELIVERED_SMS_BUNDLE, deliveredParcelable);
                 @SuppressLint("WrongConstant")
                 PendingIntent deliveredPI = PendingIntent.getBroadcast(
-                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagMutable);
+                        context, messageId, deliveredIntent, PendingIntent.FLAG_UPDATE_CURRENT | flagImmutable);
 
                 ArrayList<PendingIntent> sPI = new ArrayList<PendingIntent>();
                 ArrayList<PendingIntent> dPI = new ArrayList<PendingIntent>();
@@ -711,10 +711,10 @@ public class Transaction {
             // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
             // Actual value from:
             // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
-            final int flagMutable = 1<<25;
+            final int flagImmutable = 1 << 26;
             @SuppressLint("WrongConstant")
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(
-                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | flagMutable);
+                    context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT | flagImmutable);
 
             ExternalLogger.d("[Transaction] sendMmsThroughSystem() write message to provider");
             Uri writerUri = (new Uri.Builder())

--- a/library/src/main/java/com/klinker/android/send_message/Transaction.java
+++ b/library/src/main/java/com/klinker/android/send_message/Transaction.java
@@ -275,7 +275,7 @@ public class Transaction {
                 sentIntent.putExtra(SENT_SMS_BUNDLE, sentMessageParcelable);
                 // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
                 // Actual value from:
-                // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+                // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#247
                 final int flagImmutable = 1 << 26;
                 @SuppressLint("WrongConstant")
                 PendingIntent sentPI = PendingIntent.getBroadcast(
@@ -710,7 +710,7 @@ public class Transaction {
             intent.putExtra(MmsSentReceiver.EXTRA_FILE_PATH, mSendFile.getPath());
             // Workaround for using PendingIntent.FLAG_MUTABLE until compileSdkVersion is updated to 31.
             // Actual value from:
-            // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#262
+            // https://android.googlesource.com/platform/frameworks/base.git/+/android-13.0.0_r18/core/java/android/app/PendingIntent.java#247
             final int flagImmutable = 1 << 26;
             @SuppressLint("WrongConstant")
             final PendingIntent pendingIntent = PendingIntent.getBroadcast(


### PR DESCRIPTION
Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.